### PR TITLE
Add pylint action with Google style configuration.

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,24 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+        wget https://google.github.io/styleguide/pylintrc
+    - name: Analysing the code with pylint
+      run: |
+        pylint --rcfile pylintrc $(git ls-files '*.py')


### PR DESCRIPTION
This would run pylint with the official Google style configuration on every PR automatically, saving us quite a bit of time.

We can [already see results of it in this PR](https://github.com/google-research/big_vision/runs/7743498832?check_suite_focus=true)

However, it seems that maybe we should submit the configuration here and fine-tune it a bit? I'm seeing several lint errors that we don't actually hit internally, for example:
![image](https://user-images.githubusercontent.com/1476029/183621817-7fb67169-194f-4cbe-b284-10067b9f1329.png)
So we should see if we like this difference, and/or where it comes from, before merging.