### PR TITLE
Reduce peak memory usage when freezing parameters.

### DIFF
--- a/big_vision/optax.py
+++ b/big_vision/optax.py
@@ -68,7 +68,7 @@ def make(config, params, *, sched_kw):
       # Removes weight decay updates. Note that weight decay already has an
       # independent mask (which cannot be combined easily with a second mask),
       # so instead we multiply updates for frozen params with zero.
-      optax.masked(optax.scale(0.0), frozen_mask)
+      optax.masked(optax.set_to_zero(), frozen_mask)
   ]
 
   # Gradient clipping.


### PR DESCRIPTION
I discovered a `optax.set_to_zero()` from this [thread](https://github.com/google/flax/discussions/1706).

When compare with the original `optax.scale(0.0)` on a ViT H/16 with some heads, peak GPU memory usage (by setting XLA_PYTHON_CLIENT_PREALLOCATE=false):
- Full trainable: 18GiB
- optax.scale(0.0) (current): 9.8GiB
- optax.set_to_zero (PR): 5.6GiB

The frozen weight was set in the config like this (for both current and PR change):
```
  config.schedule = [
    (".*ViT_0/.*", None),
    (".*", dict(warmup_steps=2500))
  ]
```

Theoretically memory usage should be the same after jitted, so I'm not sure if this is a GPU-specific bug from jax or not.