### PR TITLE
Setting Kaggle Credentials

### DIFF
--- a/big_vision/configs/proj/paligemma/finetune_paligemma.ipynb
+++ b/big_vision/configs/proj/paligemma/finetune_paligemma.ipynb
@@ -37,7 +37,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "DfxKb3F839Ks",
         "outputId": "d02e98d5-8334-463f-f529-6292dd73b04b",
@@ -101,7 +101,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "zGLIp1Cx3_CX"
       },
@@ -119,7 +119,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "source": [
+        "#If you encounter issues with the cell above, please try using this one\n",
+        "!mkdir ~/.kaggle\n",
+        "!touch ~/.kaggle/kaggle.json\n",
+        "\n",
+        "api_token = {\"username\":\"KAGGLE_USERNAME\",\"key\":\"KAGGLE_KEY\"}\n",
+        "\n",
+        "import json\n",
+        "\n",
+        "with open('/root/.kaggle/kaggle.json', 'w') as file:\n",
+        "    json.dump(api_token, file)"
+      ],
+      "metadata": {
+        "id": "tbLUyEjnV4ut"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -196,7 +216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -255,7 +275,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "id": "1aghcULcEdtv"
       },
@@ -281,7 +301,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -388,7 +408,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "id": "8SRW0NuU4UcW"
       },
@@ -446,7 +466,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "id": "whzWOojGOtzi"
       },
@@ -504,7 +524,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -606,7 +626,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "dwUV_imW3WQJ"
       },
@@ -692,7 +712,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1019,7 +1039,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",


### PR DESCRIPTION
The existing code in the notebook for setting Kaggle credentials uses the Colab-specific userdata.get API, which may not work outside Colab. The added method works in different environments. It simply creates a .kaggle directory and writes the API token to a kaggle.json file.